### PR TITLE
doc: fix incorrect cloning URL in CONTRIBUTING.md (closes #34)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ If you are worried about or don’t know where to start, check out the next sect
 ### 1. Clone the repository with git
 
 ```bash
-git clone https://github.com/appwrite/console.git appwrite-assistant
+git clone https://github.com/appwrite/assistant.git appwrite-assistant
 ```
 
 ### 2. Install dependencies with pnpm


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
This PR fixes an incorrect cloning URL in the `assistant/CONTRIBUTING.md` file. Previously, it instructed users to clone the Appwrite Console repository instead of the Appwrite's Assistant repository. 

### Before:
- `git clone https://github.com/appwrite/console.git appwrite-assistant`

### After:
-  `git clone https://github.com/appwrite/assistant.git appwrite-assistant`


## Why is this change needed?

New contributors might accidentally clone the wrong repository and get confused while trying to set up their development environment. This fix ensures contributors clone the correct repository for Appwrite Assistant.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Closes #34